### PR TITLE
Update palette.blockMeshParams.blockPalette value

### DIFF
--- a/tools/headless-config.ts
+++ b/tools/headless-config.ts
@@ -13,7 +13,7 @@ export const headlessConfig = {
     palette: {
         blockMeshParams: {
             textureAtlas: 'vanilla', // Must be an atlas name that exists in /resources/atlases
-            blockPalette: 'all-supported', // Must be a palette name that exists in /resources/palettes
+            blockPalette: 'all-snapshot', // Must be a palette name that exists in /resources/palettes
             ditheringEnabled: true,
             colourSpace: 'rgb', // 'rgb' / 'lab';
             fallable: 'replace-falling', // 'replace-fallable' / 'place-string';


### PR DESCRIPTION
Changed the value of palette.blockMeshParams.blockPalette from "all-supported" to "all-snapshot", as "all-supported.palette" was renamed to "all-snapshot.palette" in b6e26a5573f8d4f0b30e6de07b05d3beb74d7f1c