### PR TITLE
Added grass-like blocks replacement when an opaque block is on top

### DIFF
--- a/res/block_ids.json
+++ b/res/block_ids.json
@@ -1398,15 +1398,5 @@
         "id": 252,
         "meta": 15,
         "name": "Black Concrete Powder"
-    },
-    "minecraft:crimson_nylium": {
-        "id": 487,
-        "meta": 0,
-        "name": "Crimson Nylium"
-    },
-    "minecraft:warped_nylium": {
-        "id": 252,
-        "meta": 15,
-        "name": "Warped Nylium"
     }
 }

--- a/res/block_ids.json
+++ b/res/block_ids.json
@@ -1398,5 +1398,15 @@
         "id": 252,
         "meta": 15,
         "name": "Black Concrete Powder"
+    },
+    "minecraft:crimson_nylium": {
+        "id": 487,
+        "meta": 0,
+        "name": "Crimson Nylium"
+    },
+    "minecraft:warped_nylium": {
+        "id": 252,
+        "meta": 15,
+        "name": "Warped Nylium"
     }
 }

--- a/res/grass_like_blocks.json
+++ b/res/grass_like_blocks.json
@@ -1,0 +1,11 @@
+{
+    "grass_like_blocks": [
+        "minecraft:grass_block",
+        "minecraft:grass_path",
+        "minecraft:podzol",
+        "minecraft:crimson_nylium",
+        "minecraft:warped_nylium",
+        "minecraft:mycelium",
+        "minecraft:farmland"
+    ]
+}

--- a/src/block_mesh.ts
+++ b/src/block_mesh.ts
@@ -164,25 +164,25 @@ export class BlockMesh {
                     id: this._blocks.length,
                     voxelColour: voxelColour,
                     errWeight: blockMeshParams.errorWeight,
-                    faceVisibility: faceVisibility
+                    faceVisibility: faceVisibility,
                 });
             }
-            
+
             this._blocks.push({
                 voxel: voxel,
                 blockInfo: block,
             });
-            this._blocksUsed.add(block.name);                       
+            this._blocksUsed.add(block.name);
         }
 
-        if (grassLikeBlocksBuffer.length>0){
+        if (grassLikeBlocksBuffer.length > 0) {
             const nonGrassLikeBlockCollection = atlasPalette.createBlockCollection(this._grassLikeBlocks);
-            for (let index=0; index<grassLikeBlocksBuffer.length; index++) {
+            for (let index=0; index < grassLikeBlocksBuffer.length; index++) {
                 ProgressManager.Get.progress(taskHandle, index / grassLikeBlocksBuffer.length);
                 const examined = grassLikeBlocksBuffer[index];
                 const examinedBlock = this._blocks[examined.id];
-                const topBlockId = this._blocks.findIndex(b => b.voxel.position.equals(Vector3.add(examinedBlock.voxel.position, new Vector3(0, 1, 0))));
-                if (topBlockId>-1 && !this._transparentBlocks.includes(this._blocks[topBlockId].blockInfo.name)){
+                const topBlockId = this._blocks.findIndex((b) => b.voxel.position.equals(Vector3.add(examinedBlock.voxel.position, new Vector3(0, 1, 0))));
+                if (topBlockId > -1 && !this._transparentBlocks.includes(this._blocks[topBlockId].blockInfo.name)) {
                     const block = atlasPalette.getBlock(examined.voxelColour, nonGrassLikeBlockCollection, examined.faceVisibility, examined.errWeight);
                     examinedBlock.blockInfo = block;
                     this._blocks[examined.id] = examinedBlock;

--- a/src/block_mesh.ts
+++ b/src/block_mesh.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 import { Atlas, TAtlasBlock } from './atlas';
-import { AtlasPalette } from './block_assigner';
+import { AtlasPalette, EFaceVisibility } from './block_assigner';
 import { BlockInfo } from './block_atlas';
 import { ChunkedBufferGenerator, TBlockMeshBufferDescription } from './buffer';
 import { RGBA_255, RGBAUtil } from './colour';
@@ -23,6 +23,13 @@ interface Block {
     blockInfo: BlockInfo;
 }
 
+interface GrassLikeBlock {
+    id: number;
+    voxelColour: RGBA_255;
+    errWeight: number;
+    faceVisibility: EFaceVisibility;
+}
+
 export type FallableBehaviour = 'replace-falling' | 'replace-fallable' | 'place-string' | 'do-nothing';
 
 export interface BlockMeshParams {
@@ -38,6 +45,7 @@ export class BlockMesh {
     private _voxelMesh: VoxelMesh;
     private _fallableBlocks: string[];
     private _transparentBlocks: string[];
+    private _grassLikeBlocks: string[];
     private _emissiveBlocks: string[];
     private _atlas: Atlas;
     private _lighting: BlockMeshLighting;
@@ -75,6 +83,9 @@ export class BlockMesh {
 
         const emissivelocksString = fs.readFileSync(PathUtil.join(AppPaths.Get.resources, 'emissive_blocks.json'), 'utf-8');
         this._emissiveBlocks = JSON.parse(emissivelocksString).emissive_blocks;
+
+        const grassLikeBlocksString = fs.readFileSync(PathUtil.join(AppPaths.Get.resources, 'grass_like_blocks.json'), 'utf-8');
+        this._grassLikeBlocks = JSON.parse(grassLikeBlocksString).grass_like_blocks;
     }
 
     /**
@@ -115,6 +126,7 @@ export class BlockMesh {
         const atlasPalette = new AtlasPalette(atlas, palette);
         const allBlockCollection = atlasPalette.createBlockCollection([]);
         const nonFallableBlockCollection = atlasPalette.createBlockCollection(this._fallableBlocks);
+        const grassLikeBlocksBuffer: GrassLikeBlock[] = [];
 
         let countFalling = 0;
         const taskHandle = ProgressManager.Get.start('Assigning');
@@ -147,11 +159,36 @@ export class BlockMesh {
                 block = atlasPalette.getBlock(voxelColour, nonFallableBlockCollection, faceVisibility, blockMeshParams.errorWeight);
             }
 
+            if (this._grassLikeBlocks.includes(block.name)) {
+                grassLikeBlocksBuffer.push({
+                    id: this._blocks.length,
+                    voxelColour: voxelColour,
+                    errWeight: blockMeshParams.errorWeight,
+                    faceVisibility: faceVisibility
+                });
+            }
+            
             this._blocks.push({
                 voxel: voxel,
                 blockInfo: block,
             });
-            this._blocksUsed.add(block.name);
+            this._blocksUsed.add(block.name);                       
+        }
+
+        if (grassLikeBlocksBuffer.length>0){
+            const nonGrassLikeBlockCollection = atlasPalette.createBlockCollection(this._grassLikeBlocks);
+            for (let index=0; index<grassLikeBlocksBuffer.length; index++) {
+                ProgressManager.Get.progress(taskHandle, index / grassLikeBlocksBuffer.length);
+                const examined = grassLikeBlocksBuffer[index];
+                const examinedBlock = this._blocks[examined.id];
+                const topBlockId = this._blocks.findIndex(b => b.voxel.position.equals(Vector3.add(examinedBlock.voxel.position, new Vector3(0, 1, 0))));
+                if (topBlockId>-1 && !this._transparentBlocks.includes(this._blocks[topBlockId].blockInfo.name)){
+                    const block = atlasPalette.getBlock(examined.voxelColour, nonGrassLikeBlockCollection, examined.faceVisibility, examined.errWeight);
+                    examinedBlock.blockInfo = block;
+                    this._blocks[examined.id] = examinedBlock;
+                    this._blocksUsed.add(block.name);
+                };
+            }
         }
         ProgressManager.Get.end(taskHandle);
 


### PR DESCRIPTION
Since the blocks are determined in a for() loop, you can't really know if the block on top of the current one will be transparent or not while you're in the loop. So I had to add a second one after which corrects the grassy blocks that had an opaque block on top. There might be a better implementation but I couldn't find one.