### PR TITLE
GLTF Multiple Materials Fix

### DIFF
--- a/src/importers/gltf_loader.ts
+++ b/src/importers/gltf_loader.ts
@@ -31,17 +31,22 @@ export class GltfLoader extends IImporter {
         const meshTexcoords: UV[] = [];
         const meshTriangles: Tri[] = [];
         const meshMaterials: MaterialMap = new Map();
+
         meshMaterials.set('NONE', {
             type: MaterialType.solid,
             colour: RGBAUtil.copy(RGBAColours.WHITE),
             needsAttention: false,
             canBeTextured: false,
         });
+
         let maxIndex = 0;
+        let materialIndex = 0; // New variable to create unique material identifiers
 
         Object.values(gltf.meshes).forEach((mesh: any) => {
             Object.values(mesh.primitives).forEach((primitive: any) => {
                 const attributes = primitive.attributes;
+
+                // Handling vertices
                 if (attributes.POSITION !== undefined) {
                     const positions = attributes.POSITION.value as Float32Array;
                     for (let i = 0; i < positions.length; i += 3) {
@@ -52,6 +57,8 @@ export class GltfLoader extends IImporter {
                         ));
                     }
                 }
+
+                // Handling normals
                 if (attributes.NORMAL !== undefined) {
                     const normals = attributes.NORMAL.value as Float32Array;
                     for (let i = 0; i < normals.length; i += 3) {
@@ -62,6 +69,8 @@ export class GltfLoader extends IImporter {
                         ));
                     }
                 }
+
+                // Handling texture coordinates
                 if (attributes.TEXCOORD_0 !== undefined) {
                     const texcoords = attributes.TEXCOORD_0.value as Float32Array;
                     for (let i = 0; i < texcoords.length; i += 2) {
@@ -71,125 +80,82 @@ export class GltfLoader extends IImporter {
                         ));
                     }
                 }
+
                 // Material
-                let materialNameToUse = 'NONE';
-                {
-                    if (primitive.material) {
-                        const materialName = primitive.material.name;
+                let materialBaseName = 'NONE';
+                if (primitive.material) {
+                    materialBaseName = primitive.material.name || 'Material';
+                }
 
-                        let materialMade = false;
+                const materialNameToUse = materialBaseName + '_' + materialIndex; // Unique material identifier
+                materialIndex++; // Increment material index
 
-                        const pbr = primitive.material.pbrMetallicRoughness;
-                        if (pbr !== undefined) {
-                            const diffuseTexture = pbr.baseColorTexture;
-                            if (diffuseTexture !== undefined) {
-                                const imageData: Uint8Array = diffuseTexture.texture.source.bufferView.data;
-                                const mimeType: string = diffuseTexture.texture.source.mimeType;
+                // Handling materials
+                if (primitive.material) {
+                    const pbr = primitive.material.pbrMetallicRoughness;
+                    if (pbr !== undefined) {
+                        const diffuseTexture = pbr.baseColorTexture;
+                        if (diffuseTexture !== undefined) {
+                            const imageData: Uint8Array = diffuseTexture.texture.source.bufferView.data;
+                            const mimeType: string = diffuseTexture.texture.source.mimeType;
 
-                                try {
-                                    if (mimeType !== 'image/png' && mimeType !== 'image/jpeg') {
-                                        StatusHandler.warning(LOC('import.unsupported_image_type', { file_name: diffuseTexture.texture.source.id, file_type: mimeType }));
-                                        throw new Error('Unsupported image type');
-                                    }
-
-                                    const base64 = btoa(
-                                        imageData.reduce((data, byte) => data + String.fromCharCode(byte), ''),
-                                    );
-
-                                    meshMaterials.set(materialName, {
-                                        type: MaterialType.textured,
-                                        diffuse: {
-                                            filetype: mimeType === 'image/jpeg' ? 'jpg' : 'png',
-                                            raw: (mimeType === 'image/jpeg' ? 'data:image/jpeg;base64,' : 'data:image/png;base64,') + base64,
-                                        },
-                                        extension: 'clamp',
-                                        interpolation: 'linear',
-                                        needsAttention: false,
-                                        transparency: { type: 'None' },
-                                    });
-                                } catch {
-                                    meshMaterials.set(materialName, {
-                                        type: MaterialType.solid,
-                                        colour: RGBAUtil.copy(RGBAColours.WHITE),
-                                        needsAttention: false,
-                                        canBeTextured: true,
-                                    });
+                            try {
+                                if (mimeType !== 'image/png' && mimeType !== 'image/jpeg') {
+                                    StatusHandler.warning(LOC('import.unsupported_image_type', { file_name: diffuseTexture.texture.source.id, file_type: mimeType }));
+                                    throw new Error('Unsupported image type');
                                 }
 
+                                const base64 = btoa(
+                                    imageData.reduce((data, byte) => data + String.fromCharCode(byte), ''),
+                                );
 
-                                /*
-
-                                */
-
-                                materialNameToUse = materialName;
-                                materialMade = true;
-                            } else {
-                                const diffuseColour: (number[] | undefined) = pbr.baseColorFactor;
-
-                                if (diffuseColour !== undefined) {
-                                    meshMaterials.set(materialName, {
-                                        type: MaterialType.solid,
-                                        colour: {
-                                            r: diffuseColour[0],
-                                            g: diffuseColour[1],
-                                            b: diffuseColour[2],
-                                            a: diffuseColour[3],
-                                        },
-                                        needsAttention: false,
-                                        canBeTextured: false,
-                                    });
-                                }
-
-                                materialNameToUse = materialName;
-                                materialMade = true;
+                                meshMaterials.set(materialNameToUse, {
+                                    type: MaterialType.textured,
+                                    diffuse: {
+                                        filetype: mimeType === 'image/jpeg' ? 'jpg' : 'png',
+                                        raw: (mimeType === 'image/jpeg' ? 'data:image/jpeg;base64,' : 'data:image/png;base64,') + base64,
+                                    },
+                                    extension: 'clamp',
+                                    interpolation: 'linear',
+                                    needsAttention: false,
+                                    transparency: { type: 'None' },
+                                });
+                            } catch {
+                                meshMaterials.set(materialNameToUse, {
+                                    type: MaterialType.solid,
+                                    colour: RGBAUtil.copy(RGBAColours.WHITE),
+                                    needsAttention: false,
+                                    canBeTextured: true,
+                                });
                             }
                         }
-
-                        const emissiveColour: (number[] | undefined) = primitive.material.pbr;
-                        if (!materialMade && emissiveColour !== undefined) {
-                            meshMaterials.set(materialName, {
-                                type: MaterialType.solid,
-                                colour: {
-                                    r: emissiveColour[0],
-                                    g: emissiveColour[1],
-                                    b: emissiveColour[2],
-                                    a: 1.0,
-                                },
-                                needsAttention: false,
-                                canBeTextured: false,
-                            });
-
-                            materialNameToUse = materialName;
-                            materialMade = true;
-                        }
                     }
                 }
+
                 // Indices
-                {
-                    const indices = primitive.indices.value as Uint16Array;
-                    for (let i = 0; i < indices.length / 3; ++i) {
-                        meshTriangles.push({
-                            material: materialNameToUse,
-                            positionIndices: {
-                                x: maxIndex + indices[i * 3 + 0],
-                                y: maxIndex + indices[i * 3 + 1],
-                                z: maxIndex + indices[i * 3 + 2],
-                            },
-                            texcoordIndices: {
-                                x: maxIndex + indices[i * 3 + 0],
-                                y: maxIndex + indices[i * 3 + 1],
-                                z: maxIndex + indices[i * 3 + 2],
-                            },
-                        });
-                    }
-
-                    let localMax = 0;
-                    for (let i = 0; i < indices.length; ++i) {
-                        localMax = Math.max(localMax, indices[i]);
-                    }
-
-                    maxIndex += localMax + 1;
+                const indices = primitive.indices.value as Uint16Array;
+                for (let i = 0; i < indices.length / 3; ++i) {
+                    meshTriangles.push({
+                        material: materialNameToUse,
+                        positionIndices: {
+                            x: maxIndex + indices[i * 3 + 0],
+                            y: maxIndex + indices[i * 3 + 1],
+                            z: maxIndex + indices[i * 3 + 2],
+                        },
+                        texcoordIndices: {
+                            x: maxIndex + indices[i * 3 + 0],
+                            y: maxIndex + indices[i * 3 + 1],
+                            z: maxIndex + indices[i * 3 + 2],
+                        },
+                    });
                 }
+
+                let localMax = 0;
+                for (let i = 0; i < indices.length; ++i) {
+                    localMax = Math.max(localMax, indices[i]);
+                }
+
+                maxIndex += localMax + 1;
             });
         });
 


### PR DESCRIPTION
Added support for multiple materials, which fixes a GLTF import issue where certain objects (like 3D Tiles) with multiple materials would load in incorrectly.

See these screenshots for before and after:
![image](https://github.com/user-attachments/assets/eeb13bde-1062-4990-80ec-bcb709a53ad1)

![image](https://github.com/user-attachments/assets/f25b2610-9aa9-4b88-95b0-f677b2349713)

Ended up fixing this GLTF loading bug as part of a larger project (Voxel Earth, @ [voxelearth.org](https://voxelearth.org)), where we used your NodeJS code headlessly for a CPU-based voxelizer before switching to a GPU-based voxelizer (cuda_voxelizer) as the CPU-based version was a little too slow for our needs. 

Honestly, would like to add support for GPU-based voxelizer here as well, it's just a binary program we compiled that runs on the host computer to voxelize and can probably spit back into the correct data format here. Currently just made it spit out GLB and Minecraft files for our needs (loading voxelized Earth into browser / MC) but I imagine it would be a large QOL fix for big models here.

Also- let me know if I need to adjust licensing, Lucas. Love your work- but wanted to MIT our Voxel Earth, which I clarify by saying your library is under a separate BSD-3 license, but let me know if you'd like me to adjust my work's license to match yours or just offer a combined or separate BSD-3 for Voxel Earth & ObjToSchematic. 

Thanks,

Ryan